### PR TITLE
連合なしの設定を追加、Misskeyへの投稿と同時にツイートも行う設定を追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,26 +1,28 @@
 {
   "name": "Misstter",
-  "version": "1.0.0",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "Misstter",
-      "version": "1.0.0",
+      "version": "1.0.5",
       "dependencies": {
         "@emotion/react": "^11.10.5",
         "@emotion/styled": "^11.10.5",
         "@mui/icons-material": "^5.11.0",
         "@mui/material": "^5.11.0",
         "react": "^17.0.1",
-        "react-dom": "^17.0.1"
+        "react-dom": "^17.0.1",
+        "webextension-polyfill": "^0.10.0"
       },
       "devDependencies": {
         "@types/chrome": "0.0.158",
         "@types/jest": "^27.0.2",
         "@types/react": "^17.0.0",
         "@types/react-dom": "^17.0.0",
-        "copy-webpack-plugin": "^9.0.1",
+        "@types/webextension-polyfill": "^0.10.1",
+        "copy-webpack-plugin": "^9.1.0",
         "jest": "^27.2.1",
         "prettier": "^2.2.1",
         "rimraf": "^3.0.2 ",
@@ -1528,6 +1530,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/webextension-polyfill": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@types/webextension-polyfill/-/webextension-polyfill-0.10.1.tgz",
+      "integrity": "sha512-Sdg+E2F5JUbhkE1qX15QUxpyhfMFKRGJqND9nb1C0gNN4NR7kCV31/1GvNbg6Xe+m/JElJ9/lG5kepMzjGPuQw==",
+      "dev": true
+    },
     "node_modules/@types/yargs": {
       "version": "16.0.4",
       "dev": true,
@@ -2250,16 +2258,16 @@
       "license": "MIT"
     },
     "node_modules/copy-webpack-plugin": {
-      "version": "9.0.1",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-9.1.0.tgz",
+      "integrity": "sha512-rxnR7PaGigJzhqETHGmAcxKnLZSR5u1Y3/bcIv/1FnqXedcL/E2ewK7ZCNrArJKCiSv8yVXhTqetJh8inDvfsA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "fast-glob": "^3.2.5",
-        "glob-parent": "^6.0.0",
+        "fast-glob": "^3.2.7",
+        "glob-parent": "^6.0.1",
         "globby": "^11.0.3",
         "normalize-path": "^3.0.0",
-        "p-limit": "^3.1.0",
-        "schema-utils": "^3.0.0",
+        "schema-utils": "^3.1.1",
         "serialize-javascript": "^6.0.0"
       },
       "engines": {
@@ -4289,20 +4297,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/p-limit": {
-      "version": "3.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "yocto-queue": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/p-locate": {
       "version": "4.1.0",
       "dev": true,
@@ -5302,6 +5296,11 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/webextension-polyfill": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/webextension-polyfill/-/webextension-polyfill-0.10.0.tgz",
+      "integrity": "sha512-c5s35LgVa5tFaHhrZDnr3FpQpjj1BB+RXhLTYUxGqBVN460HkbM8TBtEqdXWbpTKfzwCcjAZVF7zXCYSKtcp9g=="
+    },
     "node_modules/webidl-conversions": {
       "version": "6.1.0",
       "dev": true,
@@ -5613,17 +5612,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/yocto-queue": {
-      "version": "0.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/src/background/MisskeyAPI.ts
+++ b/src/background/MisskeyAPI.ts
@@ -39,6 +39,7 @@ export const postToMisskey = async (text: string, attachments: AttachmentData[],
   if (fileIDs.length > 0) { body["fileIds"] = fileIDs }
   if (options.cw) { body["cw"] = "" }
   if (options.scope) { body["visibility"] = options.scope }
+  if (options.localOnly) { body["localOnly"] = options.localOnly }
 
   const res = await fetch(`${options.server}/api/notes/create`, {
     method: 'POST',

--- a/src/common/CommonType.ts
+++ b/src/common/CommonType.ts
@@ -15,7 +15,8 @@ export type PostOptions = {
   token: string,
   server: string,
   sensitive: boolean,
-  scope: Scope
+  scope: Scope,
+  localOnly: boolean
 }
 
 export type PostMessage = {

--- a/src/content_script/Clients/tweetdeck.ts
+++ b/src/content_script/Clients/tweetdeck.ts
@@ -11,7 +11,7 @@ const addMisskeyPostButton = (tweetButton: HTMLElement, tweetBox: HTMLElement) =
   // すでにボタンがある場合は何もしない
   if (tweetBox.querySelector(`.${misskeyButtonClassName}`)) return;
 
-  const misskeybutton = createMisskeyPostButton(tweetToMisskey);  
+  const misskeybutton = createMisskeyPostButton(tweetToMisskey, tweetButton);
   misskeybutton.style.width = "40px"
   misskeybutton.style.height = "30px"
   misskeybutton.style.marginLeft = "8px"

--- a/src/content_script/Clients/tweetdeck.ts
+++ b/src/content_script/Clients/tweetdeck.ts
@@ -1,9 +1,10 @@
-import { REPLY_BUTTON_LABELS } from '../../common/Constants';
+import { REPLY_BUTTON_LABELS } from '../../common/constants';
 import { createScopeButton, scopeButtonClassName } from "../UI/ScopeButton"
 import { createMisskeyPostButton, misskeyButtonClassName, syncDisableState } from "../UI/MisskeyPostButton"
 import { createMisskeyImageOptionButton } from "../UI/ImageFlagButton"
 // DeckではTwitterCrawlerがそのまま使用可能
 import { tweetToMisskey } from '../System/TwitterCrawler';
+import {createLocalOnlyButton, localOnlyButtonClassName} from "../UI/LocalOnlyButton";
 
 // ミスキーへの投稿ボタンを追加する
 const addMisskeyPostButton = (tweetButton: HTMLElement, tweetBox: HTMLElement) => {
@@ -26,6 +27,13 @@ const addScopeButton = (iconBox: HTMLElement) => {
   iconBox.appendChild(scopeButton);
 }
 
+// 連合なしボタンを作成する
+const addLocalOnlyButton = (iconBox: HTMLElement) => {
+  if (iconBox.querySelector(`.${localOnlyButtonClassName}`)) return;
+  const localOnlyButton = createLocalOnlyButton();
+  iconBox.appendChild(localOnlyButton);
+}
+
 // ミスキーへのセンシティブ設定ボタンを追加する
 const addMisskeyImageOptionButton = (editButton: HTMLElement, attachmentsImage: HTMLElement) => {
   const misskeybutton = createMisskeyImageOptionButton();
@@ -44,9 +52,12 @@ const foundTweetButtonHandler = (tweetButton: HTMLElement) => {
   if (tweetBox) { addMisskeyPostButton(tweetButton, tweetBox); }
 
 
-  // // add scope button
+  // // add scope button and local only button
   const iconsBlock = document.querySelector(gifButtonSelector)?.parentElement as HTMLElement
-  if (iconsBlock) { addScopeButton(iconsBlock); }
+  if (iconsBlock) {
+    addScopeButton(iconsBlock);
+    addLocalOnlyButton(iconsBlock);
+  }
 }
 
 const foundAttachmentsImageHandler = (attachmentsImage: HTMLElement) => {

--- a/src/content_script/Clients/tweetdeck.ts
+++ b/src/content_script/Clients/tweetdeck.ts
@@ -4,7 +4,7 @@ import { createMisskeyPostButton, misskeyButtonClassName, syncDisableState } fro
 import { createMisskeyImageOptionButton } from "../UI/ImageFlagButton"
 // DeckではTwitterCrawlerがそのまま使用可能
 import { tweetToMisskey } from '../System/TwitterCrawler';
-import {createLocalOnlyButton, localOnlyButtonClassName} from "../UI/LocalOnlyButton";
+import { createLocalOnlyButton, localOnlyButtonClassName } from "../UI/LocalOnlyButton";
 
 // ミスキーへの投稿ボタンを追加する
 const addMisskeyPostButton = (tweetButton: HTMLElement, tweetBox: HTMLElement) => {

--- a/src/content_script/Clients/twitter.tsx
+++ b/src/content_script/Clients/twitter.tsx
@@ -30,7 +30,7 @@ const addMisskeyPostButton = (tweetButton: HTMLElement, tweetBox: HTMLElement) =
   // すでにボタンがある場合は何もしない
   if (tweetBox.querySelector(`.${misskeyButtonClassName}`)) return;
 
-  const misskeybutton = createMisskeyPostButton(tweetToMisskey); 
+  const misskeybutton = createMisskeyPostButton(tweetToMisskey, tweetButton);
   
   tweetBox.appendChild(misskeybutton);
   syncDisableState(tweetButton, misskeybutton);

--- a/src/content_script/Clients/twitter.tsx
+++ b/src/content_script/Clients/twitter.tsx
@@ -1,9 +1,10 @@
 import { tweetToMisskey } from '../System/TwitterCrawler';
-import { REPLY_BUTTON_LABELS } from '../../common/Constants';
+import { REPLY_BUTTON_LABELS } from '../../common/constants';
 import { createScopeButton, scopeButtonClassName } from "../UI/ScopeButton"
 import { createMisskeyPostButton, misskeyButtonClassName, syncDisableState } from "../UI/MisskeyPostButton"
 import { createMisskeyImageOptionButton } from "../UI/ImageFlagButton"
 import { showNotification } from '../UI/Notification';
+import { createLocalOnlyButton, localOnlyButtonClassName } from "../UI/LocalOnlyButton";
 
 const gifButtonSelector = 'div[data-testid="gifSearchButton"]'
 const buttonSelector = 'div[data-testid="tweetButton"], div[data-testid="tweetButtonInline"]'
@@ -15,6 +16,13 @@ const addScopeButton = (iconBox: HTMLElement) => {
   if (iconBox.querySelector(`.${scopeButtonClassName}`)) return;
   const scopeButton = createScopeButton();
   iconBox.appendChild(scopeButton);
+}
+
+// 連合なしボタンを作成する
+const addLocalOnlyButton = (iconBox: HTMLElement) => {
+  if (iconBox.querySelector(`.${localOnlyButtonClassName}`)) return;
+  const localOnlyButton = createLocalOnlyButton();
+  iconBox.appendChild(localOnlyButton);
 }
 
 // ミスキーへの投稿ボタンを追加する
@@ -47,9 +55,12 @@ const foundTweetButtonHandler = (tweetButton: HTMLElement) => {
   const tweetBox = tweetButton.parentElement as HTMLElement;
   if (tweetBox) { addMisskeyPostButton(tweetButton, tweetBox); }
 
-  // add scope button
+  // add scope button and local only button
   const iconsBlock = document.querySelector(gifButtonSelector)?.parentElement as HTMLElement
-  if (iconsBlock) { addScopeButton(iconsBlock); }
+  if (iconsBlock) {
+    addScopeButton(iconsBlock);
+    addLocalOnlyButton(iconsBlock);
+  }
 }
 
 const foundAttachmentsImageHandler = (attachmentsImage: HTMLElement) => {

--- a/src/content_script/System/StorageReader.ts
+++ b/src/content_script/System/StorageReader.ts
@@ -1,6 +1,6 @@
 import browser from 'webextension-polyfill';
 
-import { DEFAULT_INSTANCE_URL } from '../../common/Constants';
+import { DEFAULT_INSTANCE_URL } from '../../common/constants';
 import { showNotification } from '../UI/Notification'
 
 export const getToken = async () => {
@@ -47,6 +47,14 @@ export const getScope = async () => {
   return await new Promise<string>((resolve, reject) => {
     browser.storage.sync.get(['misskey_scope']).then((result) => {
       resolve(result?.misskey_scope ?? "public")
+    })
+  })
+}
+
+export const getLocalOnly = async () => {
+  return await new Promise<boolean>((resolve, reject) => {
+    browser.storage.sync.get(['misskey_local_only']).then((result) => {
+      resolve(result?.misskey_local_only ?? false)
     })
   })
 }

--- a/src/content_script/System/TwitterCrawler.ts
+++ b/src/content_script/System/TwitterCrawler.ts
@@ -2,7 +2,7 @@ import { postToMisskey } from './PostAPI'
 import { showNotification } from '../UI/Notification'
 import { Scope } from '../UI/ScopeModal';
 import { misskeyFlagAttribute, misskeyFlagClassName } from '../UI/ImageFlagButton';
-import { getCW, getScope, getSensitive, getServer, getToken } from "./StorageReader"
+import {getCW, getLocalOnly, getScope, getSensitive, getServer, getToken} from "./StorageReader"
 import { Attachment } from '../../common/CommonType';
 
 const getTweetText = () => {
@@ -58,11 +58,11 @@ export const tweetToMisskey = async () => {
       return;
     }
   
-    const [token, server, cw, sensitive, scope] = await Promise.all([
-      getToken(), getServer(), getCW(), getSensitive(), getScope(),
+    const [token, server, cw, sensitive, scope, localOnly] = await Promise.all([
+      getToken(), getServer(), getCW(), getSensitive(), getScope(), getLocalOnly(),
     ])
   
-    const options = { cw, token, server, sensitive, scope: scope as Scope }
+    const options = { cw, token, server, sensitive, scope: scope as Scope, localOnly }
     await postToMisskey(text ?? "", images, video, options);
   } catch (e) {
     console.error(e)

--- a/src/content_script/System/TwitterCrawler.ts
+++ b/src/content_script/System/TwitterCrawler.ts
@@ -2,7 +2,7 @@ import { postToMisskey } from './PostAPI'
 import { showNotification } from '../UI/Notification'
 import { Scope } from '../UI/ScopeModal';
 import { misskeyFlagAttribute, misskeyFlagClassName } from '../UI/ImageFlagButton';
-import {getCW, getLocalOnly, getScope, getSensitive, getServer, getToken} from "./StorageReader"
+import { getCW, getLocalOnly, getScope, getSensitive, getServer, getToken } from "./StorageReader"
 import { Attachment } from '../../common/CommonType';
 
 const getTweetText = () => {

--- a/src/content_script/UI/Icons.ts
+++ b/src/content_script/UI/Icons.ts
@@ -33,3 +33,22 @@ export const flag_icon = `
 export const modal_pin_icon = `
 <svg viewBox="0 0 24 24"><g><path d="M22 17H2L12 6l10 11z"></path></g></svg>
 `
+
+export const global_icon = `
+<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-rocket" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="#86ad00" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+    <path d="M4 13a8 8 0 0 1 7 7a6 6 0 0 0 3 -5a9 9 0 0 0 6 -8a3 3 0 0 0 -3 -3a9 9 0 0 0 -8 6a6 6 0 0 0 -5 3" />
+    <path d="M7 14a6 6 0 0 0 -3 6a6 6 0 0 0 6 -3" />
+    <path d="M15 9m-1 0a1 1 0 1 0 2 0a1 1 0 1 0 -2 0" />
+</svg>
+`
+
+export const local_only_icon = `
+<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-rocket-off" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="#D24728" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+    <path d="M9.29 9.275a9.03 9.03 0 0 0 -.29 .725a6 6 0 0 0 -5 3a8 8 0 0 1 7 7a6 6 0 0 0 3 -5c.241 -.085 .478 -.18 .708 -.283m2.428 -1.61a9 9 0 0 0 2.864 -6.107a3 3 0 0 0 -3 -3a9 9 0 0 0 -6.107 2.864" />
+    <path d="M7 14a6 6 0 0 0 -3 6a6 6 0 0 0 6 -3" />
+    <path d="M15 9m-1 0a1 1 0 1 0 2 0a1 1 0 1 0 -2 0" />
+    <path d="M3 3l18 18" />
+</svg>
+`

--- a/src/content_script/UI/ImageFlagButton.ts
+++ b/src/content_script/UI/ImageFlagButton.ts
@@ -9,6 +9,7 @@ export const createMisskeyImageOptionButton = () => {
   misskeybutton.style.fill = 'rgb(255, 255, 255)';
   misskeybutton.className = misskeyFlagClassName;
   misskeybutton.style.backgroundColor = "rgba(15, 20, 25, 0.75)"
+  // @ts-ignore
   misskeybutton.style.backdropFilter = "blur(4px)"
   misskeybutton.style.borderRadius = '9999px';
   misskeybutton.style.height = '32px';

--- a/src/content_script/UI/LocalOnlyButton.ts
+++ b/src/content_script/UI/LocalOnlyButton.ts
@@ -1,6 +1,5 @@
 import browser from 'webextension-polyfill';
-import {global_icon, home_scope_icon, local_only_icon, lock_scope_icon, public_scope_icon} from "./Icons";
-import {Scope} from "./ScopeModal";
+import { global_icon, local_only_icon } from "./Icons";
 
 export const localOnlyButtonClassName = 'misskey-local-only-button'
 

--- a/src/content_script/UI/LocalOnlyButton.ts
+++ b/src/content_script/UI/LocalOnlyButton.ts
@@ -1,0 +1,64 @@
+import browser from 'webextension-polyfill';
+import {global_icon, home_scope_icon, local_only_icon, lock_scope_icon, public_scope_icon} from "./Icons";
+import {Scope} from "./ScopeModal";
+
+export const localOnlyButtonClassName = 'misskey-local-only-button'
+
+export const createLocalOnlyButton = () => {
+    const localOnlyButton = document.createElement('div');
+
+    const updateLocalOnlyIcon = () => browser.storage.sync.get(['misskey_local_only']).then((result) => {
+        const localOnly = result?.misskey_local_only ?? false;
+        updateLocalOnlyButton(localOnlyButton, localOnly);
+    });
+
+    setInterval(() => {
+        updateLocalOnlyIcon();
+    }, 2000);
+
+    updateLocalOnlyIcon();
+
+    browser.storage.sync.get(['misskey_show_local_only'])
+        .then((result) => {
+            const showLocalOnly = result?.misskey_show_local_only ?? true;
+            if (!showLocalOnly) {
+                localOnlyButton.style.display = 'none';
+            }
+        });
+    localOnlyButton.className = localOnlyButtonClassName;
+    localOnlyButton.style.width = '34px';
+    localOnlyButton.style.height = '34px';
+    localOnlyButton.style.backgroundColor = 'transparent';
+    localOnlyButton.style.display = 'flex'
+    localOnlyButton.style.alignItems = 'center'
+    localOnlyButton.style.justifyContent = 'center'
+    localOnlyButton.style.borderRadius = '9999px';
+    localOnlyButton.style.cursor = 'pointer';
+    localOnlyButton.style.transition = 'background-color 0.2s ease-in-out';
+    localOnlyButton.onmouseover = () => {
+        localOnlyButton.style.backgroundColor = 'rgba(134, 179, 0, 0.1)';
+    }
+    localOnlyButton.onmouseout = () => {
+        localOnlyButton.style.backgroundColor = 'transparent';
+    }
+
+    localOnlyButton.onclick = () => {
+        browser.storage.sync.get(['misskey_local_only'])
+            .then((result) => {
+                const localOnly = result?.misskey_local_only ?? false;
+                browser.storage.sync.set({ misskey_local_only: !localOnly });
+                updateLocalOnlyIcon();
+            });
+    }
+
+    return localOnlyButton;
+}
+
+export const updateLocalOnlyButton = (localOnlyButton: HTMLDivElement, localOnly: boolean) => {
+    if (localOnly) {
+        localOnlyButton.innerHTML = local_only_icon
+    }
+    else {
+        localOnlyButton.innerHTML = global_icon
+    }
+}

--- a/src/content_script/UI/MisskeyPostButton.ts
+++ b/src/content_script/UI/MisskeyPostButton.ts
@@ -2,7 +2,7 @@ import browser from 'webextension-polyfill';
 
 export const misskeyButtonClassName = 'misskey-button'
 
-export const createMisskeyPostButton = (tweetToMisskeyFunc: () => Promise<void>) => {
+export const createMisskeyPostButton = (tweetToMisskeyFunc: () => Promise<void>, tweetButton: HTMLElement) => {
   const misskeyIcon = document.createElement('img')
   misskeyIcon.src = browser.runtime.getURL('misskey_icon.png');
   misskeyIcon.style.width = '24px';
@@ -41,6 +41,11 @@ export const createMisskeyPostButton = (tweetToMisskeyFunc: () => Promise<void>)
       .then(() => {
         misskeybutton.style.opacity = '1';
         misskeybutton.disabled = false;
+        browser.storage.sync.get(['misskey_auto_tweet'])
+            .then((result) => {
+              const autoTweet = result?.misskey_auto_tweet ?? false;
+              if (autoTweet) tweetButton.click();
+            });
       })
   }
 

--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -10,16 +10,18 @@ const Popup = () => {
   const [cw, setCw] = useState<boolean | null>(null)
   const [sensitive, setSensitive] = useState<boolean | null>(null)
   const [showAccess, setShowAccess] = useState<boolean | null>(null)
-  const [showLocalOnly, setShowLocalOnly] = useState<boolean|null>(null)
+  const [showLocalOnly, setShowLocalOnly] = useState<boolean | null>(null)
+  const [autoTweet, setAutoTweet] = useState<boolean | null>(null)
 
   useEffect(() => {
-    browser.storage.sync.get(['misskey_token', 'misskey_server', 'misskey_cw', 'misskey_sensitive', 'misskey_access', "misskey_show_local_only"]).then((result) => {
+    browser.storage.sync.get(['misskey_token', 'misskey_server', 'misskey_cw', 'misskey_sensitive', 'misskey_access', "misskey_show_local_only", "misskey_auto_tweet"]).then((result) => {
       const token = result?.misskey_token; if (token) { setToken(token) }
       const server = result?.misskey_server; if (server) { setServer(server) }
       setCw(result?.misskey_cw)
       setSensitive(result?.misskey_sensitive)
       setShowAccess(result?.misskey_access)
       setShowLocalOnly(result?.misskey_show_local_only)
+      setAutoTweet(result?.misskey_auto_tweet)
     })
   }, [])
   
@@ -46,9 +48,13 @@ const Popup = () => {
     setShowAccess(access)
     browser.storage.sync.set({ misskey_access: access })
   }
-  const updateShowLocalOnly = (showLocalOnly: boolean): void => {
+  const updateShowLocalOnly = (showLocalOnly: boolean) => {
       setShowLocalOnly(showLocalOnly)
       browser.storage.sync.set({misskey_show_local_only: showLocalOnly})
+  }
+  const updateAutoTweet = (autoTweet: boolean) => {
+      setAutoTweet(autoTweet)
+      browser.storage.sync.set({misskey_auto_tweet: autoTweet})
   }
 
   const openDonationPage = () => {
@@ -144,6 +150,16 @@ const Popup = () => {
               }}
           />}
           label={<Typography style={{ fontSize: 15 }}>投稿の連合なし設定ボタンを表示する。</Typography>}
+        />
+
+        <FormControlLabel
+          control={<Checkbox
+              checked={autoTweet ?? false}
+              onChange={(e) => {
+                  updateAutoTweet(e.target.checked)
+              }}
+          />}
+          label={<Typography style={{ fontSize: 15 }}>Misskeyへの投稿後自動的にツイートする。</Typography>}
         />
 
         <Typography

--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -2,22 +2,24 @@ import browser from 'webextension-polyfill';
 import React, { useEffect, useState } from "react"
 import ReactDOM from "react-dom"
 import { Container, Typography, AppBar, Toolbar, TextField, FormControlLabel, Checkbox } from "@mui/material"
-import { DEFAULT_INSTANCE_URL } from "../common/Constants";
+import { DEFAULT_INSTANCE_URL } from "../common/constants";
 
 const Popup = () => {
   const [token, setToken] = useState<string | null>(null)
   const [server, setServer] = useState<string | null>(DEFAULT_INSTANCE_URL);
   const [cw, setCw] = useState<boolean | null>(null)
   const [sensitive, setSensitive] = useState<boolean | null>(null)
-  const [showAccess, setShowAccess] = useState<boolean|null>(null)
+  const [showAccess, setShowAccess] = useState<boolean | null>(null)
+  const [showLocalOnly, setShowLocalOnly] = useState<boolean|null>(null)
 
   useEffect(() => {
-    browser.storage.sync.get(['misskey_token', 'misskey_server', 'misskey_cw', 'misskey_sensitive', 'misskey_access']).then((result) => {
+    browser.storage.sync.get(['misskey_token', 'misskey_server', 'misskey_cw', 'misskey_sensitive', 'misskey_access', "misskey_show_local_only"]).then((result) => {
       const token = result?.misskey_token; if (token) { setToken(token) }
       const server = result?.misskey_server; if (server) { setServer(server) }
       setCw(result?.misskey_cw)
       setSensitive(result?.misskey_sensitive)
       setShowAccess(result?.misskey_access)
+      setShowLocalOnly(result?.misskey_show_local_only)
     })
   }, [])
   
@@ -43,6 +45,10 @@ const Popup = () => {
   const updateAccess = (access: boolean) => {
     setShowAccess(access)
     browser.storage.sync.set({ misskey_access: access })
+  }
+  const updateShowLocalOnly = (showLocalOnly: boolean): void => {
+      setShowLocalOnly(showLocalOnly)
+      browser.storage.sync.set({misskey_show_local_only: showLocalOnly})
   }
 
   const openDonationPage = () => {
@@ -128,6 +134,16 @@ const Popup = () => {
             }}
           />}
           label={<Typography style={{ fontSize: 15 }}>投稿の公開範囲設定ボタンを表示する。</Typography>}
+        />
+
+        <FormControlLabel
+          control={<Checkbox
+              checked={showLocalOnly ?? true}
+              onChange={(e) => {
+                  updateShowLocalOnly(e.target.checked)
+              }}
+          />}
+          label={<Typography style={{ fontSize: 15 }}>投稿の連合なし設定ボタンを表示する。</Typography>}
         />
 
         <Typography

--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -14,7 +14,7 @@ const Popup = () => {
   const [autoTweet, setAutoTweet] = useState<boolean | null>(null)
 
   useEffect(() => {
-    browser.storage.sync.get(['misskey_token', 'misskey_server', 'misskey_cw', 'misskey_sensitive', 'misskey_access', "misskey_show_local_only", "misskey_auto_tweet"]).then((result) => {
+    browser.storage.sync.get(['misskey_token', 'misskey_server', 'misskey_cw', 'misskey_sensitive', 'misskey_access', 'misskey_show_local_only', 'misskey_auto_tweet']).then((result) => {
       const token = result?.misskey_token; if (token) { setToken(token) }
       const server = result?.misskey_server; if (server) { setServer(server) }
       setCw(result?.misskey_cw)


### PR DESCRIPTION
## 変更内容
- Misskeyと同様のアイコンで連合のあり・なしを変更できるような設定を追加しました
- Misskeyへの投稿を行ったあと、自動的にツイートも行えるような設定を追加しました

## 変更理由
- 連合なしで投稿を行いたかったため
- 2つのボタンを押すのが面倒だったため

## その他
`constans.ts`が`common/Constans`としてimportされていましたが、私の環境ではビルドできなかったため`common/constants`としてimportするように変更しました
これはおそらくOSXのファイルシステムでは大文字小文字を区別しないためだと思われます(参考：https://qiita.com/miyarappo/items/8be91a3f83abcd272363)
Macを持っていないため検証できませんでしたが、変更したとしても変わらずビルドすることは可能だと思います