### PR TITLE
画像4枚での順序を修正

### DIFF
--- a/src/content_script/System/TwitterCrawler.ts
+++ b/src/content_script/System/TwitterCrawler.ts
@@ -44,6 +44,10 @@ const getTweetImages: () => Promise<Attachment[]> = async () => {
     res.push({ blob: blob, isSensitive: isFlagged })
   }
 
+  if (res.length === 4) {
+    [res[1], res[2]] = [res[2], res[1]]
+  }
+
   return res;
 }
 


### PR DESCRIPTION
## 修正内容

添付画像が4枚の場合、2枚目と3枚目を入れ替える処理を追加。

## 修正理由

4枚添付されている場合、1→3→2→4の順になってしまうため。

## 備考

Blueに加入していないため、TweetDeckでの検証はできていません。


