### PR TITLE
投稿するテキストの取得先を変更

### DIFF
--- a/src/content_script/System/TwitterCrawler.ts
+++ b/src/content_script/System/TwitterCrawler.ts
@@ -6,7 +6,7 @@ import { getCW, getLocalOnly, getScope, getSensitive, getServer, getToken } from
 import { Attachment } from '../../common/CommonType';
 
 const getTweetText = () => {
-  const textContents = document.querySelectorAll('div[data-testid="tweetTextarea_0"] div[data-block="true"]');
+  const textContents = document.querySelectorAll('label[data-testid="tweetTextarea_0_label"]');
   if (!textContents) return;
   const text = Array.from(textContents).map((textContent) => {
     return textContent.textContent;
@@ -52,16 +52,16 @@ export const tweetToMisskey = async () => {
     const text = getTweetText();
     const images = await getTweetImages();
     const video = await getTweetVideo();
-  
+
     if (!text && images.length == 0 && !video) {
       showNotification('Misskeyへの投稿内容がありません', 'error')
       return;
     }
-  
+
     const [token, server, cw, sensitive, scope, localOnly] = await Promise.all([
       getToken(), getServer(), getCW(), getSensitive(), getScope(), getLocalOnly(),
     ])
-  
+
     const options = { cw, token, server, sensitive, scope: scope as Scope, localOnly }
     await postToMisskey(text ?? "", images, video, options);
   } catch (e) {


### PR DESCRIPTION
## 修正内容

Misskeyへの投稿文の取得先要素を修正

## 修正理由

Twitter（現X）の仕様変更により、従来のセレクタでは投稿文を取得できなくなっていたため

## 備考

TweetDeck・Safariでの動作確認はできていません。